### PR TITLE
Only persist incoming auth headers if the 'access-token' is truthy

### DIFF
--- a/src/j-toker.js
+++ b/src/j-toker.js
@@ -1211,7 +1211,7 @@
       }
 
       // persist headers for next request
-      if (!blankHeaders) {
+      if (newHeaders['access-token'] && !blankHeaders) {
         root.auth.persistData(SAVED_CREDS_KEY, newHeaders);
       }
     }


### PR DESCRIPTION
This is a temporary (?) solution before https://github.com/lynndylanhurley/devise_token_auth/pull/703 is rolled back.

Once https://github.com/lynndylanhurley/devise_token_auth/issues/1159 is implemented, this PR would probably be obsolete.

Relates to https://github.com/lynndylanhurley/j-toker/issues/42