### PR TITLE
Removing function literal for CSP compliance

### DIFF
--- a/src/j-toker.js
+++ b/src/j-toker.js
@@ -27,7 +27,9 @@
     factory(window.jQuery, window.deparam, window.PubSub);
   }
 }(function ($, deparam, PubSub) {
-  var root = Function('return this')(); // jshint ignore:line
+  var root = function() {
+    return this;
+  }();
 
   // singleton baby
   if (root.auth) {


### PR DESCRIPTION
The function literal call `Function('return this')` is not compliant with a CSP without `script-src 'unsafe-eval'`, minor tweak to replace it without using a function literal.

**note:** Haven't run unit tests or anything so best to not merge until this is well tested.